### PR TITLE
Automate autoload building #6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,13 @@
     "classmap": [
       "src/"
     ]
+  },
+  "require-dev": {
+    "theseer/autoload": "^1.23"
+  },
+  "scripts" : {
+    "post-autoload-dump": [
+      "@php vendor/bin/phpab src/ > src/autoload.php"
+    ]
   }
 }
-


### PR DESCRIPTION
Possible solution for #6. I added theseer/autoload and added a script that runs phpab after composer autoload build. So composer install triggers phpab:

```$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
> @php vendor/bin/phpab src/ > src/autoload.php
```

This, however, might not work correctly on windows. Feel free to refuse the PR or improve it, right now it was just a proof of concept. It work's however.