### PR TITLE
Add .gitattribute file with export-ignore rules for build/test files to reduce the dist zip file size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/tests           export-ignore
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+/.php_cs.dist    export-ignore
+/.travis.yml     export-ignore
+/build.xml       export-ignore
+/phive.xml       export-ignore
+/phpunit.xml     export-ignore
+/psalm.xml       export-ignore


### PR DESCRIPTION
Similar to phar-io/manifest#10, adding a .gitattributes file can greatly reduce the zip file size when a zip file is downloaded via Github/composer. 

Thank you.