### PR TITLE
make dev suffix rank works for uppercase too

### DIFF
--- a/src/PreReleaseSuffix.php
+++ b/src/PreReleaseSuffix.php
@@ -60,6 +60,8 @@ class PreReleaseSuffix {
      * @param $value
      */
     private function mapValueToScore($value): int {
+        $value = strtolower($value);
+        
         if (\array_key_exists($value, self::valueScoreMap)) {
             return self::valueScoreMap[$value];
         }


### PR DESCRIPTION
Hi, I wanted to release a new version after BETA, with name RC, but they were the same.

I digged deeper and discoverd the score is incorrectly interpreted for uppercase.

- rc -> 3
- RC -> 0
- beta -> 2
- BETA -> 0

This PR fixes this behavior:

```diff
 rc -> 3
-RC -> 0
+RC -> 3
 beta -> 2
-BETA -> 0
+BETA -> 2
```
