### PR TITLE
Normalise Licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of copyright holder nor the names of contributors
+* Neither the name of the copyright holder nor the names of contributors
   may be used to endorse or promote products derived from this software
   without specific prior written permission.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-phar-io/version
-
 Copyright (c) 2016-2017 Arne Blankerts <arne@blankerts.de>, Sebastian Heuer <sebastian@phpeople.de> and contributors
 All rights reserved.
 
@@ -13,7 +11,7 @@ are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of Arne Blankerts nor the names of contributors
+* Neither the name of copyright holder nor the names of contributors
   may be used to endorse or promote products derived from this software
   without specific prior written permission.
 


### PR DESCRIPTION
Github currently doesn't know this is a BSD 3 clause licence, This change allows github to pick up the correct licence